### PR TITLE
Enable Browser cache for country calls.

### DIFF
--- a/Controller/CountryController.php
+++ b/Controller/CountryController.php
@@ -2,6 +2,9 @@
 
 namespace Endereco\Oxid6Client\Controller;
 
+use OxidEsales\Eshop\Core\Header;
+use OxidEsales\Eshop\Core\Registry;
+
 class CountryController extends \OxidEsales\Eshop\Application\Controller\FrontendController
 {
     public function render()
@@ -19,6 +22,29 @@ class CountryController extends \OxidEsales\Eshop\Application\Controller\Fronten
             $returnValue = $oCountry->getIdByCode($countryCode);
         }
 
+        $this->setContentTyp('text/plain');
+        $this->setBrowserCache('+2 Year');
+
         \OxidEsales\Eshop\Core\Registry::getUtils()->showMessageAndExit($returnValue);
+    }
+
+    private function setContentTyp($type)
+    {
+        Registry::get(Header::class)->setHeader(
+            'Content-Type: ' . $type
+        );
+    }
+
+    private function setBrowserCache($time)
+    {
+        $dateTime = date_create($time);
+
+        Registry::get(Header::class)->setHeader(
+            'Cache-Control: public, only-if-cached, max-age=' . $dateTime->getTimestamp()
+        );
+
+        Registry::get(Header::class)->setHeader(
+            'Expires: ' . $dateTime->format(DATE_RFC7231)
+        );
     }
 }


### PR DESCRIPTION
Hi,

eine Empfehlung wäre, die API Calls zu cachen im Browser.
Das spart extrem viele aufrufe an Server und Datenbank! Dadurch wird das Script noch schneller.

Wenn durch einen Krieg keine Grenzen verschoben werden. Denke ich wird es in den nächsten 100 Jahren die Daten sich niemals verändern.
Daher sollte man den Browser sagen er kann es cachen und unsere Server werden entlastet!!