### PR TITLE
Fixes null issue with shipping_ams_session_counter

### DIFF
--- a/Controller/UserComponent.php
+++ b/Controller/UserComponent.php
@@ -164,7 +164,7 @@ class UserComponent extends UserComponent_parent
         $aDelAddress = $this->_getDelAddressData();
         $sAddressId = $this->getConfig()->getRequestParameter('oxaddressid');
         $shippingAmsWasInitiated = isset($_POST['shipping_ams_session_counter']);
-        $shippingAmsWasUsed = intval($_POST['shipping_ams_session_counter']) > 0;
+        $shippingAmsWasUsed = intval($_POST['shipping_ams_session_counter'] ?? 0) > 0;
         if ($aDelAddress && $sAddressId && $shippingAmsWasInitiated && $shippingAmsWasUsed) {
             $hash = $this->calculateHash(
                 $aDelAddress['oxaddress__oxcountryid'], // Country ID


### PR DESCRIPTION
Fixes an issue in PHP 8+ where accessing a variable that is not instantiated causes a warning instead of a notice.

There was another place this was happening on my local machine but I'll make a separate pull request when I encounter it again.