### PR TITLE
The Smarty parent block call was moved to the top of the block becaus…

### DIFF
--- a/application/views/agent-include.tpl
+++ b/application/views/agent-include.tpl
@@ -1,5 +1,5 @@
+[{$smarty.block.parent}]
 [{if $oView->getClassName() != 'oxUBase'}]
     [{oxid_include_widget cl="enderecoconfig" curClass=$oView->getClassName()}]
 [{/if}]
 
-[{$smarty.block.parent}]


### PR DESCRIPTION
…e oxid_include_widget interrupts the inheritance chain.