### PR TITLE
Add lint check for endereco.js

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,10 @@
             "@phpcs",
             "@phpmd",
             "@phpstan",
-            "@phpcompat"
+            "@phpcompat",
+            "@lint"
         ],
+        "lint": "npm run lint",
         "phpcbf": "phpcbf --standard=PSR12 --ignore=vendor/*,shops/*,node_modules/* ./**/*.php",
         "phpcs": "phpcs --standard=PSR12 --ignore=vendor/*,shops/*,node_modules/* ./**/*.php",
         "phpstan": [

--- a/endereco.js
+++ b/endereco.js
@@ -7,7 +7,7 @@ import 'polyfill-array-includes';
 if ('NodeList' in window && !NodeList.prototype.forEach) {
     NodeList.prototype.forEach = function (callback, thisArg) {
         thisArg = thisArg || window;
-        for (var i = 0; i < this.length; i++) {
+        for (let i = 0; i < this.length; i++) {
             callback.call(thisArg, this[i], i, this);
         }
     };
@@ -43,18 +43,18 @@ EnderecoIntegrator.postfix = {
 };
 
 EnderecoIntegrator.css = css[0][1];
-EnderecoIntegrator.resolvers.countryCodeWrite = function (value, subscriber) {
-    return new Promise(function (resolve, reject) {
+EnderecoIntegrator.resolvers.countryCodeWrite = function (value, _subscriber) {
+    return new Promise(function (resolve, _reject) {
         resolve(window.EnderecoIntegrator.countryMapping[value.toUpperCase()]);
     });
-}
-EnderecoIntegrator.resolvers.countryCodeRead = function (value, subscriber) {
-    return new Promise(function (resolve, reject) {
+};
+EnderecoIntegrator.resolvers.countryCodeRead = function (value, _subscriber) {
+    return new Promise(function (resolve, _reject) {
         resolve(window.EnderecoIntegrator.countryMappingReverse[value]);
     });
-}
+};
 
-EnderecoIntegrator.resolvers.subdivisionCodeWrite = function (value, subscriber) {
+EnderecoIntegrator.resolvers.subdivisionCodeWrite = function (value, _subscriber) {
     return new Promise(resolve => {
         if (!value) {
             resolve('');
@@ -65,7 +65,7 @@ EnderecoIntegrator.resolvers.subdivisionCodeWrite = function (value, subscriber)
         const key = mapping[value];
         resolve(key !== undefined ? key : '');
     });
-}
+};
 
 // Transforms the internal OXID state ID (from the states select element) into an
 // ISO 3166-2 subdivision code that the JS-SDK and Endereco WebAPI expect.
@@ -77,7 +77,7 @@ EnderecoIntegrator.resolvers.subdivisionCodeWrite = function (value, subscriber)
 EnderecoIntegrator.resolvers.subdivisionCodeRead = async function (value, subscriber) {
     // Resolve country code. The SDK may not have it yet during init,
     // so fall back to the helper element's country ID.
-    var countryCode = subscriber._subject.countryCode?.toUpperCase() || '';
+    let countryCode = subscriber._subject.countryCode?.toUpperCase() || '';
     if (!countryCode && subscriber._subject.fullName) {
         const helper = document.querySelector(
             '[data-endereco-subdivision-helper="' + subscriber._subject.fullName + '"]'
@@ -96,7 +96,7 @@ EnderecoIntegrator.resolvers.subdivisionCodeRead = async function (value, subscr
 
     // If the select has no value, distinguish "user chose no subdivision" from
     // "select not populated yet". Only fall back to the helper in the latter case.
-    var effectiveValue = value;
+    let effectiveValue = value;
     const itIsSelectElement = subscriber.object && subscriber.object.tagName === 'SELECT';
     if (!effectiveValue && subscriber._subject.fullName && itIsSelectElement) {
         const mapping = window.EnderecoIntegrator?.subdivisionMappingReverse || {};
@@ -122,7 +122,7 @@ EnderecoIntegrator.resolvers.subdivisionCodeRead = async function (value, subscr
     const submapping = mapping[countryCode] || {};
     const key = submapping[effectiveValue];
     return key !== undefined ? key : '';
-}
+};
 
 EnderecoIntegrator.resolvers.countryCodeSetValue = function (subscriber, value) {
     if (subscriber.dispatchEvent('endereco-change')) {
@@ -137,55 +137,55 @@ EnderecoIntegrator.resolvers.countryCodeSetValue = function (subscriber, value) 
         } else {
             subscriber.object.value = value;
         }
-        if (!!$) {
+        if ($) {
             $(subscriber.object).trigger('change');
         }
         subscriber.lastValue = value;
         subscriber._allowFieldInspection = true;
         subscriber.dispatchEvent('endereco-blur');
     }
-}
+};
 
 EnderecoIntegrator.resolvers.subdivisionCodeSetValue = function (subscriber, value) {
     if (subscriber.dispatchEvent('endereco-change')) {
         subscriber._allowFieldInspection = false;
         if (
-          !!$ &&
-          subscriber.object &&
-          subscriber.object.classList.contains('selectpicker') &&
-          !!$(subscriber.object).selectpicker
+            !!$ &&
+            subscriber.object &&
+            subscriber.object.classList.contains('selectpicker') &&
+            !!$(subscriber.object).selectpicker
         ) {
             $(subscriber.object).selectpicker('val', value);
         } else {
             subscriber.object.value = value;
         }
-        if (!!$) {
+        if ($) {
             $(subscriber.object).trigger('change');
         }
         subscriber.lastValue = value;
         subscriber._allowFieldInspection = true;
         subscriber.dispatchEvent('endereco-blur');
     }
-}
+};
 
-EnderecoIntegrator.resolvers.salutationWrite = function (value, subscriber) {
-    var mapping = {
+EnderecoIntegrator.resolvers.salutationWrite = function (value, _subscriber) {
+    const mapping = {
         'f': 'MRS',
         'm': 'MR'
     };
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve, _reject) {
         resolve(mapping[value]);
     });
-}
-EnderecoIntegrator.resolvers.salutationRead = function (value, subscriber) {
-    var mapping = {
+};
+EnderecoIntegrator.resolvers.salutationRead = function (value, _subscriber) {
+    const mapping = {
         'MRS': 'f',
         'MR': 'm'
     };
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve, _reject) {
         resolve(mapping[value]);
     });
-}
+};
 
 EnderecoIntegrator.resolvers.salutationSetValue = function (subscriber, value) {
     if (subscriber.dispatchEvent('endereco-change')) {
@@ -204,16 +204,16 @@ EnderecoIntegrator.resolvers.salutationSetValue = function (subscriber, value) {
         subscriber._allowFieldInspection = true;
         subscriber.dispatchEvent('endereco-blur');
     }
-}
+};
 
 EnderecoIntegrator.afterAMSActivation.push( function(EAO) {
-    if (!!document.querySelector('[type="checkbox"][name="blshowshipaddress"]')) {
+    if (document.querySelector('[type="checkbox"][name="blshowshipaddress"]')) {
         if (document.querySelector('[type="checkbox"][name="blshowshipaddress"]').checked) {
             if ('shipping_address' === EAO.addressType) {
                 EAO.active = false;
             }
         }
-        document.querySelector('[type="checkbox"][name="blshowshipaddress"]').addEventListener('change', function(e) {
+        document.querySelector('[type="checkbox"][name="blshowshipaddress"]').addEventListener('change', function(_e) {
             if ('shipping_address' === EAO.addressType) {
                 EAO.active = !document.querySelector('[type="checkbox"][name="blshowshipaddress"]').checked;
             }
@@ -317,7 +317,7 @@ const checkSelectValuesAgainstMapping = (domElementOfSelect, mappingObject) => {
     }
 
     return result;
-}
+};
 
 /**
  * This function is needed to simulate blur, change and other events for better compatibility with frontend validation
@@ -344,13 +344,13 @@ window.EnderecoIntegrator.prepareDOMElement = (DOMElement, addressObject) => {
         e.target.dispatchEvent(new CustomEvent('focus', { bubbles: true, cancelable: true }));
         e.target.dispatchEvent(new CustomEvent('blur', { bubbles: true, cancelable: true }));
         prevActiveElement.dispatchEvent(new CustomEvent('focus', { bubbles: true, cancelable: true }));
-    }
+    };
 
     DOMElement.addEventListener('endereco-blur', enderecoBlurListener);
 
     // Mark the element as prepared
     DOMElement._enderecoBlurListenerAttached = true;
-}
+};
 
 if (window.EnderecoIntegrator) {
     window.EnderecoIntegrator = merge(EnderecoIntegrator, window.EnderecoIntegrator);
@@ -392,7 +392,7 @@ window.EnderecoIntegrator.isAddressFormStillValid = (EAO) => {
     }
 
     return true;
-}
+};
 
 const waitForConfig = setInterval(function () {
     if (typeof enderecoLoadAMSConfig === 'function') {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { includeIgnoreFile } from '@eslint/compat';
+import js from '@eslint/js';
+import globals from 'globals';
+
+const gitignorePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '.gitignore'
+);
+
+export default [
+    includeIgnoreFile(gitignorePath),
+    { ignores: ['out/**'] },
+    js.configs.recommended,
+    {
+        files: ['endereco.js'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                $: 'readonly',
+                jQuery: 'readonly',
+                enderecoLoadAMSConfig: 'readonly',
+            },
+        },
+        rules: {
+            eqeqeq: ['error', 'always'],
+            'no-shadow': 'error',
+            'no-var': 'error',
+            'prefer-const': 'error',
+            'no-unused-expressions': 'error',
+            'no-self-compare': 'error',
+            'no-template-curly-in-string': 'error',
+            radix: 'error',
+            'no-unused-vars': [
+                'error',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+            ],
+
+            semi: ['error', 'always'],
+            quotes: ['error', 'single', { avoidEscape: true }],
+            indent: ['error', 4, { SwitchCase: 1 }],
+            'no-trailing-spaces': 'error',
+            'eol-last': ['error', 'always'],
+        },
+    },
+];

--- a/package.json
+++ b/package.json
@@ -4,19 +4,26 @@
   "description": "",
   "main": "endereco.js",
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --progress"
+    "build": "cross-env NODE_ENV=production webpack --progress",
+    "lint": "eslint endereco.js"
   },
   "author": "ilja_weber <ilja@endereco.de>",
   "license": "ISC",
   "dependencies": {
+    "@endereco/js-sdk": "1.14.3",
     "babel-loader": "^10.0.0",
+    "css-loader": "^7.1.2",
     "html-loader": "^5.1.0",
     "polyfill-array-includes": "^2.0.0",
-    "css-loader": "^7.1.2",
     "sass-loader": "^16.0.5",
-    "@endereco/js-sdk": "1.14.3",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1"
+  },
+  "devDependencies": {
+    "@eslint/compat": "^2.0.5",
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
+    "globals": "^15.15.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Ref: [DEV-502](https://mobilemojo.atlassian.net/browse/DEV-502)

In endereco.js we integrate the JS-SDK in the shop system. It is used to create the bundle, that will be executed in he frontend.

It is currently barely verified automatically. It's pretty much just the build, that is used to verify the code. Which is not very future-proof.

So we need a foundation on which we can extend the automated verification.

One of the less invasive ones would be to use the eslint to check the code.

So use eslint to verify style and some surface level errors automatically. Add it to "composer run qa" so it can be run on each code review.  Fix issues surface by the lint check (mostly formatting).

This is merely a step towards proper validation and it doesn't provide any confidence at this moment. But still -- it's a step in the right direction.

To verify it works I:
1. Run the build script after all the changes and confirmed successful execution 
2. Went through checkout in 6.5 playground while using all services and with open browser console. I didn't see errors related to my changes and didn't notice any regresses.

The fixes in endereco.js are mostly formatting, so it looks very safe to me.

[DEV-502]: https://mobilemojo.atlassian.net/browse/DEV-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ