### PR TITLE
Remove hidden address fields on the last checkout page if needed

### DIFF
--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -10,6 +10,8 @@ use OxidEsales\Eshop\Core\Registry;
 
 class OrderController extends OrderController_parent
 {
+    private $shouldGatherBillingAddressFeedback = false;
+    private $shouldGatherShippingAddressFeedback = false;
     /**
      * Renders the order page and checks the addresses if necessary.
      * This method performs address validation for billing and delivery addresses
@@ -114,6 +116,8 @@ class OrderController extends OrderController_parent
                         );
                         $oUser->save();
                     }
+
+                    $this->shouldGatherBillingAddressFeedback = true;
                 }
 
                 // Check invoice address.
@@ -171,6 +175,8 @@ class OrderController extends OrderController_parent
                         );
                         $oDeliveryAddress->save();
                     }
+
+                    $this->shouldGatherShippingAddressFeedback = true;
                 }
             }
         }
@@ -297,5 +303,33 @@ class OrderController extends OrderController_parent
         $isCheckNeeded = $isEmpty || $hasDefaultValue;
 
         return $isCheckNeeded;
+    }
+
+    /**
+     * Returns whether billing address feedback should be gathered from the user.
+     *
+     * This flag is set during address validation in the order process and
+     * controls whether the frontend should prompt the user to confirm or
+     * correct the billing address
+     *
+     * @return bool True if billing address feedback should be gathered, false otherwise.
+     */
+    public function getShouldGatherBillingAddressFeedback(): bool
+    {
+        return $this->shouldGatherBillingAddressFeedback;
+    }
+
+    /**
+     * Returns whether shipping address feedback should be gathered from the user.
+     *
+     * This flag is used analogously to the billing address flag to indicate that
+     * the frontend should request confirmation or correction of the delivery
+     * address when address validation detects issues or ambiguity.
+     *
+     * @return bool True if shipping address feedback should be gathered, false otherwise.
+     */
+    public function getShouldGatherShippingAddressFeedback(): bool
+    {
+        return $this->shouldGatherShippingAddressFeedback;
     }
 }

--- a/application/views/hidden_fields/endereco_checkout_checkout_order_address.tpl
+++ b/application/views/hidden_fields/endereco_checkout_checkout_order_address.tpl
@@ -6,6 +6,8 @@
     data-selected-state-id="[{$oxcmp_user->oxuser__oxstateid->value}]"
 >
 <div style="display: none!important">
+    [{assign var="oBilAdressNeedsFeedback" value=$oView->getShouldGatherBillingAddressFeedback()}]
+    [{if $oBilAdressNeedsFeedback}]
     <div>
         <form>
         <input
@@ -147,9 +149,11 @@
             })();
         </script>
     </div>
+    [{/if}]
     <div>
         [{assign var="oDelAdress" value=$oView->getDelAddress()}]
-        [{if $oDelAdress}]
+        [{assign var="oDelAdressNeedsFeedback" value=$oView->getShouldGatherShippingAddressFeedback()}]
+        [{if $oDelAdress || $oDelAdressNeedsFeedback}]
         <input type="hidden"
             data-endereco-subdivision-helper="shipping_ams"
             data-country-id="[{$oDelAdress->oxaddress__oxcountryid->value}]"


### PR DESCRIPTION
On the last checkout page, we generate hidden address fields to trigger the address check for existing customers and PayPal customers. These fields trigger the address check, even if the shop owner has deactivated these features.

To deactivate these unnecessary checks, two new flags have been added. So the hidden fields are only generate when they are needed.

DEV-504